### PR TITLE
Simplify calls to sendPacket

### DIFF
--- a/src/Client/client.cpp
+++ b/src/Client/client.cpp
@@ -100,7 +100,7 @@ void Client::handleIoThread() {
 
     } else if (regex_match(cmdline, cmdarg, lsr)) {
       bool stop = false;
-      command_manager->sendPacket(t_LIST, 1, "");
+      command_manager->sendPacket(t_LIST, 1);
       while (!stop) {
         packet pkt_received = command_manager->receivePacket();
 

--- a/src/Client/client.cpp
+++ b/src/Client/client.cpp
@@ -259,16 +259,19 @@ Client::Client(std::string _client_name, std::string _server_ip,
   // recebe o primeiro pacote do server
   packet pkt = command_manager->receivePacket();
   // payload do pacote está no formato PORT <port>
+
+  if( pkt.type == t_ERROR ){
+    log_error("Erro do servidor! %s. ", pkt._payload);
+    throw std::runtime_error(pkt._payload);
+  }
   log_assert( pkt.type == t_PORT, "Received package of wrong type! %d. ", pkt.type );
-  std::string payload(pkt._payload);
-  std::string port_str = payload.substr(payload.find(" ") + 1);
+  std::string port_str(pkt._payload);
   int port = std::stoi(port_str);
   this->push_port = port;
 
   // recebe o segundo pacote do server
   packet pkt2 = command_manager->receivePacket();
-  std::string payload2(pkt2._payload);
-  std::string port_str2 = payload2.substr(payload2.find(" ") + 1);
+  std::string port_str2(pkt2._payload);
   int port2 = std::stoi(port_str2);
   this->file_watcher_port = port2;
 

--- a/src/Client/client.cpp
+++ b/src/Client/client.cpp
@@ -67,12 +67,9 @@ void Client::handleIoThread() {
 
     } else if (regex_match(cmdline, cmdarg, dow)) { // faz uma copia nao sincronizada do arquivo para o diretorio local(de onde foi chamado o cliente)
       std::string file_name = cmdarg[1].str();
-      std::string command = "DOWNLOAD " + file_name;
-
-      command_manager->sendPacket(CMD, 1, vector<char>(command.begin(), command.end()));
-      // espera resposta do servidor...
+      command_manager->sendPacket(t_DOWNLOAD, 1, file_name); // espera resposta do servidor...
       packet response = command_manager->receivePacket();
-      if (std::string(response._payload, response.length) == "FILE_NOT_FOUND") {
+      if (response.type == t_FILE_NOT_FOUND) {
         log_info("Arquivo não encontrado no servidor.");
         continue;
       } else if (std::string(response._payload, response.length) == "FILE_FOUND") {
@@ -83,8 +80,7 @@ void Client::handleIoThread() {
       log_info("Escrevendo arquivo: %s", file_name.c_str());
       while (!stop) {
         packet pkt_received = command_manager->receivePacket();
-        if (std::string(pkt_received._payload, pkt_received.length) ==
-            "END_OF_FILE") {
+        if (pkt_received.type == t_END_OF_FILE) {
           stop = true;
           break;
         }
@@ -104,13 +100,11 @@ void Client::handleIoThread() {
 
     } else if (regex_match(cmdline, cmdarg, lsr)) {
       bool stop = false;
-      std::string command = "LIST";
-      command_manager->sendPacket(CMD, 1, vector<char>(command.begin(), command.end()));
-
+      command_manager->sendPacket(t_LIST, 1, "");
       while (!stop) {
         packet pkt_received = command_manager->receivePacket();
 
-        if (std::string(pkt_received._payload, pkt_received.length) == "END_OF_FILE") {
+        if (pkt_received.type == t_END_OF_FILE) {
           stop = true;
           break;
         }
@@ -183,16 +177,14 @@ void Client::handleFileThread() {
         if (event->mask & IN_CLOSE_WRITE) {
           std::string file_name = event->name;
           log_info("Arquivo modificado: %s", file_name.c_str());
-          std::string command = "WRITE " + file_name;
           watcher_push_lock.lock();
-          file_watcher_manager.sendPacket(CMD, 1, std::vector<char>(command.begin(), command.end()));
+          file_watcher_manager.sendPacket(t_WRITE, 1, file_name);
           file_watcher_manager.sendFileInChunks(file_name, MAX_PACKET_SIZE, *sync_dir_file_manager);
           watcher_push_lock.unlock();
 
         } else if (event->mask & IN_DELETE) {
           log_info("Arquivo removido: %s", filepath.c_str());
-          std::string command = "DELETE " + std::string(event->name);
-          file_watcher_manager.sendPacket(CMD, 1, std::vector<char>(command.begin(), command.end()));
+          file_watcher_manager.sendPacket(t_DELETE, 1, event->name);
         }
       }
 
@@ -218,10 +210,8 @@ void Client::handlePushThread() {
     log_info("Aguardando push do servidor...");
     packet pkt = push_receiver.receivePacket();
     std::istringstream payload_stream(pkt._payload);
-    std::string command;
-    payload_stream >> command;
 
-    if (command == "WRITE") {
+    if (pkt.type == t_WRITE) {
       std::string file_name;
       payload_stream >> file_name;
 
@@ -234,7 +224,7 @@ void Client::handlePushThread() {
         packet pkt_received = push_receiver.receivePacket();
         std::string pkt_string = std::string(pkt_received._payload, pkt_received.length);
 
-        if (pkt_string == "END_OF_FILE") {
+        if (pkt.type == t_END_OF_FILE) {
           stop = true;
           break;
         }
@@ -244,14 +234,14 @@ void Client::handlePushThread() {
       }
       watcher_push_lock.unlock();
 
-    } else if (command == "DELETE") {
+    } else if (pkt.type == t_DELETE) {
 
       std::string file_name;
       payload_stream >> file_name;
       sync_dir_file_manager->deleteFile(file_name);
 
     } else {
-      log_error("Comando desconhecido recebido do servidor: %s", command.c_str());
+      log_error("Comando desconhecido recebido do servidor: %d. ", pkt.type);
     }
   }
 }
@@ -264,13 +254,12 @@ Client::Client(std::string _client_name, std::string _server_ip,
 
   // é o socket de commandos, tem que passar para a thread de IO
   this->command_manager = new NetworkManager("CommandManager", server_ip, server_port_int);
-  std::string command = "CLIENT " + client_name;
-
-  command_manager->sendPacket(CMD, 1, std::vector<char>(command.begin(), command.end()));
+  command_manager->sendPacket(t_CLIENT, 1, client_name);
 
   // recebe o primeiro pacote do server
   packet pkt = command_manager->receivePacket();
   // payload do pacote está no formato PORT <port>
+  log_assert( pkt.type == t_PORT, "Received package of wrong type! %d. ", pkt.type );
   std::string payload(pkt._payload);
   std::string port_str = payload.substr(payload.find(" ") + 1);
   int port = std::stoi(port_str);

--- a/src/Server/ClientManager.cpp
+++ b/src/Server/ClientManager.cpp
@@ -109,8 +109,18 @@ void ClientManager::removeDevice(Device *device) {
     log_error("Erro ao remover dispositivo: %s", e.what());
   }
 }
-std::string ClientManager::getIp() { return network_manager->getIP(); }
-int ClientManager::getPort() { return network_manager->getPort(); }
+std::string ClientManager::getIp() {
+  if( network_manager == nullptr ){
+    throw std::runtime_error("GetIP without networkManager!");
+  }
+  return network_manager->getIP(); 
+}
+int ClientManager::getPort() {
+  if( network_manager == nullptr ){
+    throw std::runtime_error("GetPort without networkManager!");
+  }
+  return network_manager->getPort(); 
+}
 
 void ClientManager::add_new_backup(NetworkManager *peer_manager) {
   std::lock_guard<std::mutex> lock(device_mutex);

--- a/src/Server/ClientManager.cpp
+++ b/src/Server/ClientManager.cpp
@@ -55,16 +55,14 @@ void ClientManager::receivePushsOn(NetworkManager *network_manager) {
           std::vector<char> data(pkt_received._payload, pkt_received._payload + pkt_received.length);
           file_manager->writeFile(file_name, data);
         }
-      } else if (command == "DELETE") {
+      } else if (pkt.type == t_DELETE) {
         log_info("Removendo arquivo: %s", file_name.c_str());
         file_manager->deleteFile(file_name);
       } else {
-        log_error("Comando desconhecido recebido: %s", command.c_str());
-        log_info("Thread de recebimento de push finalizada");
+        log_error("Comando desconhecido recebido: %d ", pkt.type);
       }
     } catch (const std::runtime_error &e) {
       log_warn("Erro ao receber push: %s", e.what());
-      log_info("Thread de recebimento de push finalizada");
       break; // Sai do loop se ocorrer um erro
     }
   }

--- a/src/Server/ClientManager.cpp
+++ b/src/Server/ClientManager.cpp
@@ -41,15 +41,13 @@ void ClientManager::receivePushsOn(NetworkManager *network_manager) {
       packet pkt = network_manager->receivePacket();
       log_info("Recebendo push no clientManagerBackup\n");
       NetworkManager::printPacket(pkt);
-      std::string received_message(pkt._payload);
-      std::string command = received_message.substr(0, received_message.find(' '));
-      if (command == "WRITE") {
-        std::string file_name = received_message.substr(received_message.find(' ') + 1);
+      std::string file_name(pkt._payload);
+      if (pkt.type == t_WRITE) {
         log_info("Recebendo arquivo: %s", file_name.c_str());
         bool stop = false;
         while (!stop) {
           packet pkt_received = network_manager->receivePacket();
-          if (std::string(pkt_received._payload, pkt_received.length) == "END_OF_FILE") {
+          if ( pkt_received.type == t_END_OF_FILE) {
             stop = true;
             log_info("Recebimento do arquivo %s finalizado", file_name.c_str());
             break;
@@ -58,7 +56,6 @@ void ClientManager::receivePushsOn(NetworkManager *network_manager) {
           file_manager->writeFile(file_name, data);
         }
       } else if (command == "DELETE") {
-        std::string file_name = received_message.substr(received_message.find(' ') + 1);
         log_info("Removendo arquivo: %s", file_name.c_str());
         file_manager->deleteFile(file_name);
       } else {

--- a/src/Server/ClientManager.hpp
+++ b/src/Server/ClientManager.hpp
@@ -30,11 +30,11 @@ public:
 
 private:
   vector<Device *> devices;
-  FileManager *file_manager;
-  NetworkManager *network_manager;
+  FileManager *file_manager = nullptr;
+  NetworkManager *network_manager = nullptr;
   vector<NetworkManager *> backup_peers; // Lista de backups
   int max_devices;
-  Server *server; // Referência ao servidor
+  Server *server = nullptr; // Referência ao servidor
   string username;
   std::mutex device_mutex; // Mutex para proteger o acesso à lista de dispositivos
   State state;

--- a/src/Server/ClientManager.hpp
+++ b/src/Server/ClientManager.hpp
@@ -21,7 +21,7 @@ public:
   ClientManager(State State, string username);
   string getUsername();
   void handle_new_connection(int socket);
-  void handle_new_push(string command, Device *caller);
+  void handle_new_push(packet pkt, Device *caller);
   void removeDevice(Device *device);
   std::string getIp();
   int getPort();

--- a/src/Server/Device.cpp
+++ b/src/Server/Device.cpp
@@ -53,10 +53,10 @@ void Device::commandThread() { // thread se comporta recebendo comandos do
         std::string file_name;
         payload_stream >> file_name;
         if (!file_manager->isFileExists(file_name)) {
-          command_manager->sendPacket(t_FILE_NOT_FOUND, 1, "");
+          command_manager->sendPacket(t_FILE_NOT_FOUND, 1);
           continue;
         } else {
-          command_manager->sendPacket(t_FILE_FOUND, 1, "");
+          command_manager->sendPacket(t_FILE_FOUND, 1);
         }
         command_manager->sendFileInChunks(file_name, MAX_PACKET_SIZE,
                                           *file_manager);
@@ -73,7 +73,7 @@ void Device::commandThread() { // thread se comporta recebendo comandos do
           fim = "NAO HÁ ARQUIVOS";
         }
         command_manager->sendPacket(t_DATA, 1, vector<char>(fim.begin(), fim.end()));
-        command_manager->sendPacket(t_END_OF_FILE, 1, "");
+        command_manager->sendPacket(t_END_OF_FILE, 1);
       } else {
         log_error("Comando desconhecido recebido do cliente: %d", pkt.type);
       }

--- a/src/Server/Device.cpp
+++ b/src/Server/Device.cpp
@@ -137,12 +137,7 @@ void Device::fileWatcherThread() {
       std::string file_name(pkt._payload);
 
       // NOTE: Never used?
-      //    Interpret the packet based on the first word
-      //   if (first_word == "CREATED") {
-      //     std::string file_name;
-      //     payload_stream >> file_name;
-      //     file_manager->createFile(file_name);
-      //   } else 
+      //   if (first_word == "CREATED") file_manager->createFile(file_name);
       if (pkt.type == t_WRITE) {
 
         if (!file_manager->isFileExists(file_name)) {

--- a/src/Server/Device.hpp
+++ b/src/Server/Device.hpp
@@ -28,6 +28,8 @@ private:
   std::thread *push_thread;
   std::thread *file_watcher_thread;
   FileManager *file_manager;
+
+  int push_type;
   std::string push_command;
 
   void commandThread();
@@ -42,7 +44,7 @@ public:
   void stop();
   bool isStopRequested();
   void sendFileTo(std::string file_path);  // no socket de comando
-  void sendPushTo(std::string &file_path); // no socket de push
+  void sendPushTo(int type, std::string &file_path); // no socket de push
   void buildFile(std::string &file_name);
   ~Device();
 };

--- a/src/Utils/NetworkManager.cpp
+++ b/src/Utils/NetworkManager.cpp
@@ -207,7 +207,7 @@ void NetworkManager::sendFileInChunks(const std::string &filepath, const size_t 
                           fileData.begin() + offset + chunkSize);
 
       std::string command = payload;
-      sendPacket(DATA, sequenceNumber++,
+      sendPacket(t_DATA, sequenceNumber++,
                  std::vector<char>(command.begin(), command.end()));
       log_info("Enviado chunck de tamanho %zu do arquivo: %s, %d/%d", chunkSize,
                filepath.c_str(), sequenceNumber, totalPackets);
@@ -216,9 +216,7 @@ void NetworkManager::sendFileInChunks(const std::string &filepath, const size_t 
     }
 
     // Envia um pacote final indicando o término do envio
-    std::string command = "END_OF_FILE";
-    sendPacket(CMD, sequenceNumber,
-               std::vector<char>(command.begin(), command.end()));
+    sendPacket(t_END_OF_FILE, sequenceNumber, "");
     log_info("Arquivo enviado com sucesso: %s", filepath.c_str());
   } catch (const std::exception &e) {
     log_error("Falha ao enviar ou ler arquivo: %s", e.what());

--- a/src/Utils/NetworkManager.cpp
+++ b/src/Utils/NetworkManager.cpp
@@ -60,6 +60,9 @@ void NetworkManager::sendPacket(packet *p) {
 };
 
 
+void NetworkManager::sendPacket(uint16_t type, uint16_t seqn) {
+  sendPacket(type, seqn, "xxx");
+}
 void NetworkManager::sendPacket(uint16_t type, uint16_t seqn, const std::string &payload) {
   sendPacket(type, seqn, std::vector<char>(payload.begin(), payload.end()));
 }
@@ -101,11 +104,13 @@ void NetworkManager::checkSocketInitialized() {
 bool NetworkManager::isPacketValid(const packet &pkt) {
   // Verifica se o tamanho total do pacote é válido
   if (pkt.total_size < HEADER_SIZE || pkt.length > MAX_PACKET_SIZE) {
-    return false;
+     log_info("Invalid packet {} {}", pkt.total_size, pkt.length);
+     return false;
   }
 
   // Verifica se o payload é nulo quando o comprimento é zero
   if (pkt.length == 0 && pkt._payload != nullptr) {
+     log_info("Invalid packet {} {}", pkt.total_size, pkt.length);
     return false;
   }
 
@@ -221,7 +226,7 @@ void NetworkManager::sendFileInChunks(const std::string &filepath, const size_t 
     }
 
     // Envia um pacote final indicando o término do envio
-    sendPacket(t_END_OF_FILE, sequenceNumber, "");
+    sendPacket(t_END_OF_FILE, sequenceNumber);
     log_info("Arquivo enviado com sucesso: %s", filepath.c_str());
   } catch (const std::exception &e) {
     log_error("Falha ao enviar ou ler arquivo: %s", e.what());
@@ -283,7 +288,7 @@ packet NetworkManager::deserializePacket(const char *buffer,
   pkt.length = ntohs(net_length);
 
   if (pkt.length > buffer_size - HEADER_SIZE || pkt.length < 0) {
-    throw std::runtime_error("Invalid packet length");
+    throw std::runtime_error("Invalid packet length " + std::to_string(pkt.length) );
   }
 
   pkt._payload = new char[pkt.length + 1];
@@ -487,4 +492,25 @@ int connect_to_socket(std::string ip, int port) {
     }
   }
   return sock;
+}
+
+
+std::vector<std::string> list_to_packet_content(std::string content){
+  std::vector<std::string> result;
+  int left = 1;
+  for(int i = 1; i < content.size(); ++i){
+    if(content[i] == ';'){
+       result.push_back( content.substr(left, i) );
+       left = i;
+    } 
+  }
+  return result;
+}
+std::string list_to_packet_content(std::vector<std::string> vec){
+  // TODO escape characters ';', '[', and ']';
+  std::string result;
+  for( std::string s : vec )
+    result += s + ";";
+
+  return "[" + result + "]";
 }

--- a/src/Utils/NetworkManager.hpp
+++ b/src/Utils/NetworkManager.hpp
@@ -10,9 +10,7 @@
 #define MAX_PACKET_SIZE 2048
 
 enum PacketType {
-  /** Sends the content of a file. */
-  t_DATA = 0,
-  /** */
+  t_DATA = 0, /** Sends the content of a file. */
   t_DELETE,
   t_WRITE,
   t_FILE,

--- a/src/Utils/NetworkManager.hpp
+++ b/src/Utils/NetworkManager.hpp
@@ -61,6 +61,7 @@ public:
   void sendPacket(uint16_t type, uint16_t seqn,
                   const std::vector<char> &payload);
   void sendPacket(uint16_t type, uint16_t seqn, const std::string &payload);
+  void sendPacket(uint16_t type, uint16_t seqn);
   packet receivePacket();
   void sendFileInChunks(const std::string &filepath, const size_t bufferSize,
                         FileManager &fileManager);
@@ -88,3 +89,5 @@ private:
 };
 
 int connect_to_socket(std::string server_name, int server_port);
+std::string list_to_packet_content(std::vector<std::string> values);
+std::vector<std::string> packet_content_to_list(std::string data);

--- a/src/Utils/NetworkManager.hpp
+++ b/src/Utils/NetworkManager.hpp
@@ -2,9 +2,7 @@
 #include "FileManager.hpp"
 #include <cstdint>
 #include <memory>
-#include <netinet/in.h>
 #include <string>
-#include <sys/socket.h>
 #include <vector>
 
 #define MAX_PACKET_SIZE 2048
@@ -29,7 +27,6 @@ enum PacketType {
   t_LIST,
   t_END_OF_FILE,
   t_ERROR,
-
 };
 
 typedef struct packet {

--- a/src/Utils/NetworkManager.hpp
+++ b/src/Utils/NetworkManager.hpp
@@ -8,8 +8,31 @@
 #include <vector>
 
 #define MAX_PACKET_SIZE 2048
-#define DATA 0
-#define CMD 1
+
+enum PacketType {
+  /** Sends the content of a file. */
+  t_DATA = 0,
+  /** */
+  t_DELETE,
+  t_WRITE,
+  t_FILE,
+  t_PORT,
+  t_CLIENT,
+  t_GET_CLIENTS,
+  t_CLIENTS,
+  t_PEER,
+  t_WHO_IS_LEADER,
+  t_LEADER,
+  t_CLIENT_CONNECTION,
+  t_FILE_NOT_FOUND,
+  t_FILE_FOUND,
+  t_UPLOAD,
+  t_DOWNLOAD,
+  t_LIST,
+  t_END_OF_FILE,
+  t_ERROR,
+
+};
 
 typedef struct packet {
   uint16_t type;

--- a/src/client_main.cpp
+++ b/src/client_main.cpp
@@ -4,18 +4,9 @@
  * please only define the main() function here.
  */
 #include "Client/client.hpp"
-#include "Utils/NetworkManager.hpp"
 #include "Utils/logger.hpp"
-#include <arpa/inet.h>
-#include <chrono>
-#include <cstdlib>
-#include <cstring>
 #include <iostream>
-#include <netinet/in.h>
 #include <string>
-#include <sys/inotify.h>
-#include <sys/socket.h>
-#include <unistd.h>
 
 #define SERVER_PORT 4000
 // localhost


### PR DESCRIPTION
instead of hardcoding a space-separated command into the packet itself, we can use the packet.type member to specify which command we are trying to run.

We can then reduce 

```
std::string message = "PEER 0";
connection->sendPacket(CMD, 0, std::vector<char>(message.begin(), message.end())); 
```

to 

```
connection->sendPacket(t_PEER_MSG, 0, "0"); 
```


Some minor bugs were fixed also